### PR TITLE
Add formatted strings and custom number fonts

### DIFF
--- a/assets/std/std/color.mcl
+++ b/assets/std/std/color.mcl
@@ -83,6 +83,18 @@ let CLEAR = [0.0, 0.0, 0.0, 0]
 ## ```
 let rgb = |r, g, b, a = 1| [r, g, b, a]
 
+## [overview]
+## Build an RGBA color from a hexadecimal HTML/CSS color literal.
+## [description]
+## Accepts `#RRGGBB` or `#RRGGBBAA`; the leading `#` is optional. Six-digit colors are fully opaque.
+## [parameters]
+## value: hexadecimal color string
+## [example]
+## ```
+## mesh logo = fill{hex("#009ee0")} Circle(1)
+## ```
+let hex = |value| __monocurl__native__ hex(value)
+
 # h in [0, 1], s, v, a in [0, 1].
 ## [options]
 ## important: true

--- a/assets/std/std/mesh.mcl
+++ b/assets/std/std/mesh.mcl
@@ -472,16 +472,17 @@ let Label = |target, str, dir = 1u, scale = 1, buffer = 0.1, font = nil|
 ## [overview]
 ## Number rendered as text with optional formatting.
 ## [description]
-## With `decimal_places = nil`, formatting uses compact `%g`-style output. Set `include_sign` truthy for a leading plus sign on positive values.
+## With `decimal_places = nil`, formatting uses compact `%g`-style output. Set `include_sign` truthy for a leading plus sign on positive values. Passing a system font family or font-file path renders direct font outlines rather than the built-in number glyphs; custom fonts are native-only and are not available on web.
 ## [parameters]
 ## decimal_places: optional fixed decimal count
 ## include_sign: include plus sign for positive values
+## font: optional system font name or font filename
 ## [example]
 ## ```
-## mesh n = Number(value, 2, 1)
+## mesh n = Number(value, 2, 1, "Arial")
 ## ```
-let Number = |value, decimal_places = nil, include_sign = 0|
-    __monocurl__native__ mk_number(value, decimal_places, include_sign)
+let Number = |value, decimal_places = nil, include_sign = 0, font = nil|
+    __monocurl__native__ mk_number(value, decimal_places, include_sign, font)
 
 # graphing
 

--- a/assets/std/std/util.mcl
+++ b/assets/std/std/util.mcl
@@ -301,8 +301,12 @@ let str_join = |parts, sep = ""| __monocurl__native__ str_join(parts, sep)
 ## [overview]
 ## Convert a value to a string.
 ## [description]
-## Uses the same stringification rules as text constructors, so lists become concatenated text fragments.
-let to_string = |x| __monocurl__native__ to_string(x)
+## Non-numeric values use the same stringification rules as text constructors, so lists become concatenated text fragments. Numeric values use compact `%g`-style formatting by default; set `decimal_places` to a non-negative integer for fixed decimal formatting.
+## [example]
+## ```
+## let label = to_string(1, 1) # "1.0"
+## ```
+let to_string = |x, decimal_places = nil| __monocurl__native__ to_string(x, decimal_places)
 ## [overview]
 ## Convert an integer, float, or numeric string to an integer.
 ## [description]

--- a/crates/integration_tests/tests/basic_executor_tests/collections.rs
+++ b/crates/integration_tests/tests/basic_executor_tests/collections.rs
@@ -170,6 +170,22 @@ fn test_to_string_joins_list_elements_recursively() {
 }
 
 #[test]
+fn test_to_string_formats_numbers_with_decimal_places() {
+    let r = run_with_stdlib(
+        r#"
+        let result = [
+            to_string(1, 1),
+            to_string(-1.234, 2),
+            to_string(1.5, 0),
+            to_string(12345.678)
+        ]
+        "#,
+        &["util"],
+    );
+    r.assert_string_list(&["1.0", "-1.23", "2", "12345.7"]);
+}
+
+#[test]
 fn test_sample_includes_endpoint() {
     let r = run_with_stdlib(
         "

--- a/crates/integration_tests/tests/basic_executor_tests/collections.rs
+++ b/crates/integration_tests/tests/basic_executor_tests/collections.rs
@@ -3,6 +3,21 @@ use super::*;
 // -- collections: lists --
 
 #[test]
+fn test_iterating_map_explains_how_to_get_key_value_pairs() {
+    let r = run("\
+        let colors = [\"blue\" -> 1]
+        for ([key, value] in colors) {}
+    ");
+    r.assert_error("use map_items(map) to iterate [key, value] pairs");
+}
+
+#[test]
+fn test_hex_color_parses_html_rgb() {
+    let r = run_with_stdlib(r##"let result = hex("#009ee0")"##, &["color"]);
+    r.assert_float_list_approx(&[0.0, 158.0 / 255.0, 224.0 / 255.0, 1.0], 1e-9);
+}
+
+#[test]
 fn test_exec_empty_list() {
     let r = run("let xs = []");
     r.assert_ok();

--- a/crates/integration_tests/tests/basic_executor_tests/live_values.rs
+++ b/crates/integration_tests/tests/basic_executor_tests/live_values.rs
@@ -1528,6 +1528,22 @@ fn test_number_constructor_accepts_decimal_and_sign_options() {
 }
 
 #[test]
+fn test_number_constructor_accepts_custom_font() {
+    let font = std::env::current_dir()
+        .unwrap()
+        .join("assets/font/IBMPlexMono-Regular.ttf");
+    let font = monocurl_string_escape(&font.to_string_lossy());
+    let source = format!(
+        r#"
+        let number = Number(1.5, 1, 0, "{font}")
+        let result = len(mesh_triangle_set(number)) > 0
+        "#
+    );
+    let r = run_with_stdlib(&source, &["mesh", "util"]);
+    r.assert_int(1);
+}
+
+#[test]
 fn test_camera_transfer_preserves_camera_space_under_translation() {
     let r = run_with_stdlib(
         "

--- a/crates/monocurl/src/actions.rs
+++ b/crates/monocurl/src/actions.rs
@@ -1,6 +1,6 @@
 use gpui::actions;
 
-actions!(app, [Quit, OpenSettings, CheckForUpdates]);
+actions!(app, [Quit, OpenSettings, OpenKeyBindings, CheckForUpdates]);
 
 actions!(
     document,

--- a/crates/monocurl/src/components/mod.rs
+++ b/crates/monocurl/src/components/mod.rs
@@ -1,4 +1,5 @@
 pub mod buttons;
 pub mod latex_warning;
+pub mod prompt;
 pub mod split_pane;
 pub mod text_input;

--- a/crates/monocurl/src/components/prompt.rs
+++ b/crates/monocurl/src/components/prompt.rs
@@ -1,0 +1,114 @@
+use gpui::*;
+
+use crate::theme::ThemeSettings;
+
+pub fn init(cx: &mut App) {
+    cx.set_prompt_builder(|level, message, detail, actions, handle, window, cx| {
+        let prompt = cx.new(|cx| AppPrompt {
+            level,
+            message: message.into(),
+            detail: detail.map(str::to_owned),
+            actions: actions.to_vec(),
+            focus_handle: cx.focus_handle(),
+        });
+        handle.with_view(prompt, window, cx)
+    });
+}
+
+struct AppPrompt {
+    level: PromptLevel,
+    message: String,
+    detail: Option<String>,
+    actions: Vec<PromptButton>,
+    focus_handle: FocusHandle,
+}
+
+impl EventEmitter<PromptResponse> for AppPrompt {}
+
+impl Focusable for AppPrompt {
+    fn focus_handle(&self, _: &App) -> FocusHandle {
+        self.focus_handle.clone()
+    }
+}
+
+impl Render for AppPrompt {
+    fn render(&mut self, _: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let theme = ThemeSettings::theme(cx);
+        let title_color = match self.level {
+            PromptLevel::Critical => theme.viewport_status_runtime_error,
+            PromptLevel::Warning => theme.accent,
+            PromptLevel::Info => theme.text_primary,
+        };
+
+        let prompt = div()
+            .track_focus(&self.focus_handle)
+            .w(px(440.0))
+            .max_w(px(520.0))
+            .rounded(px(8.0))
+            .border_1()
+            .border_color(theme.navbar_border)
+            .bg(theme.app_background)
+            .p(px(18.0))
+            .flex()
+            .flex_col()
+            .gap(px(12.0))
+            .child(
+                div()
+                    .w_full()
+                    .whitespace_normal()
+                    .text_size(px(16.0))
+                    .font_weight(FontWeight::SEMIBOLD)
+                    .text_color(title_color)
+                    .child(self.message.clone()),
+            )
+            .children(self.detail.clone().map(|detail| {
+                div()
+                    .w_full()
+                    .whitespace_normal()
+                    .text_size(px(12.0))
+                    .line_height(px(18.0))
+                    .text_color(theme.text_muted)
+                    .child(detail)
+            }))
+            .child(div().flex().flex_row().justify_end().gap(px(8.0)).children(
+                self.actions.iter().enumerate().map(|(ix, action)| {
+                    div()
+                        .id(ix)
+                        .px(px(12.0))
+                        .py(px(6.0))
+                        .rounded(px(4.0))
+                        .border_1()
+                        .border_color(theme.navbar_border)
+                        .bg(theme.tab_active_background)
+                        .text_size(px(12.0))
+                        .text_color(theme.text_primary)
+                        .cursor_pointer()
+                        .hover(|style| style.opacity(0.85))
+                        .child(action.label().clone())
+                        .on_click(cx.listener(move |_, _, _, cx| {
+                            cx.emit(PromptResponse(ix));
+                            cx.stop_propagation();
+                        }))
+                }),
+            ));
+
+        div()
+            .relative()
+            .size_full()
+            .child(div().absolute().size_full().bg(Rgba {
+                r: 0.0,
+                g: 0.0,
+                b: 0.0,
+                a: 0.45,
+            }))
+            .child(
+                div()
+                    .absolute()
+                    .size_full()
+                    .flex()
+                    .items_center()
+                    .justify_center()
+                    .child(prompt),
+            )
+    }
+}

--- a/crates/monocurl/src/components/split_pane.rs
+++ b/crates/monocurl/src/components/split_pane.rs
@@ -13,6 +13,10 @@ pub struct Split {
     second: AnyElement,
     default_flex: f32,
     divider_color: Hsla,
+    flex_state: Option<Rc<Cell<f32>>>,
+    on_flex_change: Option<Rc<dyn Fn(f32, &mut App)>>,
+    min_first_size: Pixels,
+    min_second_size: Pixels,
 }
 
 impl Split {
@@ -23,6 +27,10 @@ impl Split {
             second,
             default_flex: 0.5,
             divider_color: Theme::light().split_divider.into(),
+            flex_state: None,
+            on_flex_change: None,
+            min_first_size: px(MIN_SIZE),
+            min_second_size: px(MIN_SIZE),
         }
     }
 
@@ -33,6 +41,22 @@ impl Split {
 
     pub fn divider_color(mut self, color: impl Into<Hsla>) -> Self {
         self.divider_color = color.into();
+        self
+    }
+
+    pub fn flex_state(mut self, state: Rc<Cell<f32>>) -> Self {
+        self.flex_state = Some(state);
+        self
+    }
+
+    pub fn on_flex_change(mut self, callback: impl Fn(f32, &mut App) + 'static) -> Self {
+        self.on_flex_change = Some(Rc::new(callback));
+        self
+    }
+
+    pub fn min_sizes(mut self, first: Pixels, second: Pixels) -> Self {
+        self.min_first_size = first;
+        self.min_second_size = second;
         self
     }
 }
@@ -84,12 +108,13 @@ impl Element for Split {
             let state = state.unwrap_or_else(|| Rc::new(Cell::new(false)));
             (state.clone(), state)
         });
-        let flex_handle = window.with_element_state(id.unwrap(), |state, _| {
-            let state = state.unwrap_or_else(|| Rc::new(Cell::new(self.default_flex)));
-            (state.clone(), state)
+        let flex_handle = self.flex_state.clone().unwrap_or_else(|| {
+            window.with_element_state(id.unwrap(), |state, _| {
+                let state = state.unwrap_or_else(|| Rc::new(Cell::new(self.default_flex)));
+                (state.clone(), state)
+            })
         });
 
-        let flex = flex_handle.get().clamp(0.2, 0.8);
         let is_horizontal = self.orientation == Axis::Horizontal;
 
         // Get main and cross axis dimensions
@@ -103,6 +128,11 @@ impl Element for Split {
         } else {
             bounds.size.width
         };
+        let (min_first, min_second) =
+            scaled_min_sizes(main_axis, self.min_first_size, self.min_second_size);
+        let min_flex = (min_first / main_axis).max(0.0);
+        let max_flex = (1.0 - min_second / main_axis).min(1.0);
+        let flex = flex_handle.get().clamp(min_flex, max_flex);
         let split_pos = main_axis * flex;
 
         // Helper to create bounds based on orientation
@@ -142,7 +172,10 @@ impl Element for Split {
             divider_bounds,
             drag_handle,
             flex_handle,
+            on_flex_change: self.on_flex_change.clone(),
             axis: self.orientation,
+            min_first,
+            min_second,
         }
     }
 
@@ -175,8 +208,24 @@ pub struct SplitLayout {
     handle_hitbox: Hitbox,
     divider_bounds: Bounds<Pixels>,
     flex_handle: Rc<Cell<f32>>,
+    on_flex_change: Option<Rc<dyn Fn(f32, &mut App)>>,
     drag_handle: Rc<Cell<bool>>,
     axis: Axis,
+    min_first: Pixels,
+    min_second: Pixels,
+}
+
+fn scaled_min_sizes(main_axis: Pixels, first: Pixels, second: Pixels) -> (Pixels, Pixels) {
+    if main_axis <= px(0.0) {
+        return (px(0.0), px(0.0));
+    }
+    let requested = first + second;
+    if requested <= main_axis {
+        (first, second)
+    } else {
+        let scale = f32::from(main_axis) / f32::from(requested);
+        (first * scale, second * scale)
+    }
 }
 
 fn paint_split_handle(layout: &mut SplitLayout, window: &mut Window, _cx: &mut App) {
@@ -203,17 +252,23 @@ fn paint_split_handle(layout: &mut SplitLayout, window: &mut Window, _cx: &mut A
         let axis = layout.axis;
         let is_dragging = layout.drag_handle.clone();
         let flex = layout.flex_handle.clone();
-        move |event: &MouseMoveEvent, phase, window, _cx| {
+        let on_flex_change = layout.on_flex_change.clone();
+        let min_first = layout.min_first;
+        let min_second = layout.min_second;
+        move |event: &MouseMoveEvent, phase, window, cx| {
             if phase.bubble() && is_dragging.get() {
                 let container_size = bounds.size.along(axis);
                 let offset = (event.position - bounds.origin).along(axis);
-                let min_px = px(MIN_SIZE);
-                let max_px = container_size - min_px;
+                let min_px = min_first;
+                let max_px = container_size - min_second;
 
                 let clamped_offset = offset.max(min_px).min(max_px);
                 let new_flex = (clamped_offset / container_size).clamp(0.0, 1.0);
 
                 flex.set(new_flex);
+                if let Some(callback) = &on_flex_change {
+                    callback(new_flex, cx);
+                }
                 window.refresh();
             }
         }

--- a/crates/monocurl/src/document_view/actions.rs
+++ b/crates/monocurl/src/document_view/actions.rs
@@ -364,6 +364,7 @@ impl DocumentView {
         cx: &mut Context<Self>,
     ) {
         self.is_headless = !self.is_headless;
+        self.update_workspace(|workspace| workspace.is_headless = self.is_headless, cx);
         if self.is_headless {
             self.focus(w);
         }

--- a/crates/monocurl/src/document_view/mod.rs
+++ b/crates/monocurl/src/document_view/mod.rs
@@ -1,6 +1,8 @@
 use std::{
+    cell::Cell,
     collections::HashMap,
     path::PathBuf,
+    rc::Rc,
     sync::{Arc, atomic::AtomicBool},
 };
 
@@ -24,7 +26,7 @@ use crate::{
         document_state::DocumentState,
         textual_state::LexData,
         user_settings::UserSettings,
-        window_state::{ActiveScreen, WindowState},
+        window_state::{ActiveScreen, DocumentWorkspaceState, WindowState},
     },
     theme::{FontSet, ThemeSettings},
     timeline::timeline_view::Timeline,
@@ -83,6 +85,7 @@ pub fn init(cx: &mut App) {
 pub struct OpenDocument {
     pub path: PathBuf,
     pub view: Entity<DocumentView>,
+    pub workspace: DocumentWorkspaceState,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -272,6 +275,8 @@ pub struct DocumentView {
     is_presenting: bool,
     presentation_window: Option<AnyWindowHandle>,
     is_headless: bool,
+    main_split: Rc<Cell<f32>>,
+    viewport_timeline_split: Rc<Cell<f32>>,
     controls_window: Option<WindowHandle<ControlsWindow>>,
 
     state: DocumentState,

--- a/crates/monocurl/src/document_view/render.rs
+++ b/crates/monocurl/src/document_view/render.rs
@@ -4,6 +4,7 @@ use crate::components::latex_warning::render_latex_warning;
 impl DocumentView {
     pub fn new(
         path: PathBuf,
+        workspace: DocumentWorkspaceState,
         window_state: WeakEntity<WindowState>,
         dirty: Entity<bool>,
         window: &mut Window,
@@ -30,7 +31,30 @@ impl DocumentView {
             )
         });
         let viewport = cx.new(|cx| Viewport::new(services.clone(), cx));
-        let timeline = cx.new(|cx| Timeline::new(services.clone(), editor.downgrade(), cx));
+        let workspace_path = path.clone();
+        let workspace_state = window_state.clone();
+        let on_console_change: Rc<dyn Fn(bool, f32, &mut App)> =
+            Rc::new(move |visible, split, cx| {
+                if let Some(window_state) = workspace_state.upgrade() {
+                    let path = workspace_path.clone();
+                    window_state.update(cx, |window_state, _| {
+                        window_state.update_document_workspace(&path, |workspace| {
+                            workspace.console_visible = visible;
+                            workspace.console_split = split;
+                        });
+                    });
+                }
+            });
+        let timeline = cx.new(|cx| {
+            Timeline::new(
+                services.clone(),
+                editor.downgrade(),
+                workspace.console_visible,
+                workspace.console_split,
+                on_console_change,
+                cx,
+            )
+        });
 
         let document_path = path.clone();
         let window_state_up = window_state.upgrade().unwrap();
@@ -69,7 +93,9 @@ impl DocumentView {
             was_fullscreen_before_presenting: false,
             is_presenting: false,
             presentation_window: None,
-            is_headless: false,
+            is_headless: workspace.is_headless,
+            main_split: Rc::new(Cell::new(workspace.main_split)),
+            viewport_timeline_split: Rc::new(Cell::new(workspace.viewport_timeline_split)),
             controls_window: None,
             window_state: window_state.clone(),
             state,
@@ -599,12 +625,39 @@ impl DocumentView {
     }
 
     fn viewport_timeline(&self, divider_color: impl Into<Hsla>) -> Split {
+        let workspace_state = self.window_state.clone();
+        let workspace_path = self.path.clone();
         Split::new(
             Axis::Vertical,
             self.viewport.clone().into_any_element(),
             self.timeline.clone().into_any_element(),
         )
         .divider_color(divider_color)
+        .flex_state(self.viewport_timeline_split.clone())
+        .on_flex_change(move |split, cx| {
+            if let Some(window_state) = workspace_state.upgrade() {
+                let path = workspace_path.clone();
+                window_state.update(cx, |window_state, _| {
+                    window_state.update_document_workspace(&path, |workspace| {
+                        workspace.viewport_timeline_split = split;
+                    });
+                });
+            }
+        })
+    }
+
+    pub(super) fn update_workspace(
+        &self,
+        update: impl FnOnce(&mut DocumentWorkspaceState),
+        cx: &mut App,
+    ) {
+        let Some(window_state) = self.window_state.upgrade() else {
+            return;
+        };
+        let path = self.path.clone();
+        window_state.update(cx, |window_state, _| {
+            window_state.update_document_workspace(&path, update);
+        });
     }
 
     fn render_editor(&self, cx: &mut Context<Self>) -> impl IntoElement + use<> {
@@ -628,6 +681,8 @@ impl DocumentView {
             self.viewport_timeline(theme.split_divider)
                 .into_any_element()
         } else {
+            let workspace_state = self.window_state.clone();
+            let workspace_path = self.path.clone();
             Split::new(
                 Axis::Horizontal,
                 self.render_editor(cx).into_any_element(),
@@ -636,6 +691,17 @@ impl DocumentView {
             )
             .default_flex(0.5)
             .divider_color(theme.split_divider)
+            .flex_state(self.main_split.clone())
+            .on_flex_change(move |split, cx| {
+                if let Some(window_state) = workspace_state.upgrade() {
+                    let path = workspace_path.clone();
+                    window_state.update(cx, |window_state, _| {
+                        window_state.update_document_workspace(&path, |workspace| {
+                            workspace.main_split = split;
+                        });
+                    });
+                }
+            })
             .into_any_element()
         };
 

--- a/crates/monocurl/src/editor/text_editor/mod.rs
+++ b/crates/monocurl/src/editor/text_editor/mod.rs
@@ -70,6 +70,8 @@ pub fn init(cx: &mut App) {
         KeyBinding::new("right", Right, None),
         KeyBinding::new("alt-left", LeftWord, None),
         KeyBinding::new("alt-right", RightWord, None),
+        KeyBinding::new("ctrl-left", LeftWord, None),
+        KeyBinding::new("ctrl-right", RightWord, None),
         KeyBinding::new("enter", Enter, None),
         KeyBinding::new("tab", Tab, None),
         KeyBinding::new("shift-tab", Untab, None),
@@ -79,6 +81,8 @@ pub fn init(cx: &mut App) {
         KeyBinding::new("shift-right", SelectRight, None),
         KeyBinding::new("shift-alt-left", SelectLeftWord, None),
         KeyBinding::new("shift-alt-right", SelectRightWord, None),
+        KeyBinding::new("shift-ctrl-left", SelectLeftWord, None),
+        KeyBinding::new("shift-ctrl-right", SelectRightWord, None),
         KeyBinding::new("shift-secondary-left", SelectHome, None),
         KeyBinding::new("shift-secondary-right", SelectEnd, None),
         KeyBinding::new("shift-up", SelectUp, None),
@@ -95,6 +99,8 @@ pub fn init(cx: &mut App) {
         KeyBinding::new("escape", CloseFind, Some("single-line-input")),
         KeyBinding::new("home", Home, None),
         KeyBinding::new("end", End, None),
+        KeyBinding::new("shift-home", SelectHome, None),
+        KeyBinding::new("shift-end", SelectEnd, None),
         KeyBinding::new("ctrl-secondary-space", ShowCharacterPalette, None),
     ]);
 }

--- a/crates/monocurl/src/keybindings_window.rs
+++ b/crates/monocurl/src/keybindings_window.rs
@@ -1,0 +1,199 @@
+use gpui::*;
+
+use crate::theme::{FontSet, ThemeSettings};
+
+#[derive(Default)]
+struct KeyBindingsWindowHandle {
+    window: Option<AnyWindowHandle>,
+}
+
+impl Global for KeyBindingsWindowHandle {}
+
+pub struct KeyBindingsWindow {
+    focus_handle: FocusHandle,
+}
+
+impl KeyBindingsWindow {
+    pub fn open(cx: &mut App) {
+        let window_size = size(px(560.0), px(620.0));
+        if !cx.has_global::<KeyBindingsWindowHandle>() {
+            cx.set_global(KeyBindingsWindowHandle::default());
+        }
+
+        let existing = cx.global::<KeyBindingsWindowHandle>().window;
+        if let Some(handle) = existing
+            && handle
+                .update(cx, |_, window, _| window.activate_window())
+                .is_ok()
+        {
+            return;
+        }
+
+        let options = WindowOptions {
+            titlebar: Some(TitlebarOptions {
+                title: Some("Key Bindings".into()),
+                ..Default::default()
+            }),
+            window_bounds: Some(WindowBounds::centered(window_size, cx)),
+            window_min_size: Some(size(px(420.0), px(360.0))),
+            focus: true,
+            ..Default::default()
+        };
+        if let Ok(handle) = cx.open_window(options, |_window, cx| cx.new(KeyBindingsWindow::new)) {
+            cx.update_global::<KeyBindingsWindowHandle, _>(|key_bindings, _| {
+                key_bindings.window = Some(handle.into());
+            });
+        }
+    }
+
+    fn new(cx: &mut Context<Self>) -> Self {
+        cx.observe_global::<ThemeSettings>(|_this, cx| cx.notify())
+            .detach();
+        Self {
+            focus_handle: cx.focus_handle(),
+        }
+    }
+}
+
+const BINDINGS: &[(&str, &[(&str, &str)])] = &[
+    (
+        "Application",
+        &[
+            ("Save", "Cmd/Ctrl+S"),
+            ("Save As", "Cmd/Ctrl+Shift+S"),
+            ("Close document", "Cmd/Ctrl+W"),
+            ("Find", "Cmd/Ctrl+F"),
+            ("Undo / redo", "Cmd/Ctrl+Z / Cmd/Ctrl+Shift+Z"),
+            ("Copy / cut / paste", "Cmd/Ctrl+C / X / V"),
+            ("Present", "Cmd/Ctrl+P"),
+            ("Show presentation controls", "Cmd/Ctrl+T"),
+            ("Toggle console", "Cmd/Ctrl+K"),
+            ("Sync preview camera", "Cmd/Ctrl+L"),
+            ("Toggle headless mode", "Cmd/Ctrl+Shift+H"),
+        ],
+    ),
+    (
+        "Timeline and playback",
+        &[
+            ("Play / pause", "Cmd/Ctrl+G"),
+            ("Previous / next slide", "Cmd/Ctrl+, / Cmd/Ctrl+."),
+            ("Scene start / end", "Cmd/Ctrl+< / Cmd/Ctrl+>"),
+            ("Step backward / forward", "Cmd/Ctrl+; / Cmd/Ctrl+'"),
+            ("Timeline zoom", "Cmd/Ctrl+- / Cmd/Ctrl+="),
+            ("Play / pause outside the editor", "Space / Shift+Space"),
+            (
+                "Previous / next slide outside the editor",
+                ", / . or Left / Right",
+            ),
+            ("Leave editor focus", "Esc"),
+        ],
+    ),
+    (
+        "Editor",
+        &[
+            ("Move by word", "Alt+Arrow or Ctrl+Arrow"),
+            ("Select by word", "Shift+Alt+Arrow or Shift+Ctrl+Arrow"),
+            ("Move to line start / end", "Home / End"),
+            ("Select to line start / end", "Shift+Home / Shift+End"),
+            (
+                "Select to line start / end (macOS)",
+                "Shift+Cmd+Left / Right",
+            ),
+            ("Select all", "Cmd/Ctrl+A"),
+            ("Toggle comment", "Cmd/Ctrl+/"),
+            ("Fold current slide", "Cmd/Ctrl+."),
+            ("Indent / unindent", "Tab / Shift+Tab"),
+            ("Find next / previous", "Cmd/Ctrl+G / Cmd/Ctrl+Shift+G"),
+        ],
+    ),
+];
+
+fn platform_shortcut(shortcut: &str) -> String {
+    let primary_modifier = if cfg!(target_os = "macos") {
+        "Cmd"
+    } else {
+        "Ctrl"
+    };
+    let word_modifier = if cfg!(target_os = "macos") {
+        "Option"
+    } else {
+        "Alt"
+    };
+
+    shortcut
+        .replace("Cmd/Ctrl", primary_modifier)
+        .replace("Alt", word_modifier)
+}
+
+impl Render for KeyBindingsWindow {
+    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let theme = ThemeSettings::theme(cx);
+        let sections = BINDINGS.iter().map(|(title, bindings)| {
+            div()
+                .flex()
+                .flex_col()
+                .gap(px(5.0))
+                .child(
+                    div()
+                        .text_size(px(13.0))
+                        .font_weight(FontWeight::SEMIBOLD)
+                        .child(*title),
+                )
+                .children(bindings.iter().filter_map(|(action, shortcut)| {
+                    if *action == "Select to line start / end (macOS)" && !cfg!(target_os = "macos")
+                    {
+                        return None;
+                    }
+
+                    let shortcut = platform_shortcut(shortcut);
+                    Some(
+                        div()
+                            .flex()
+                            .flex_row()
+                            .items_center()
+                            .gap(px(12.0))
+                            .child(div().flex_1().text_size(px(12.0)).child(*action))
+                            .child(
+                                div()
+                                    .text_size(px(11.0))
+                                    .text_color(theme.text_muted)
+                                    .child(shortcut),
+                            ),
+                    )
+                }))
+        });
+
+        div()
+            .font_family(FontSet::UI)
+            .size_full()
+            .bg(theme.app_background)
+            .text_color(theme.text_primary)
+            .key_context("key-bindings")
+            .track_focus(&self.focus_handle)
+            .child(
+                div()
+                    .id("key-bindings-scroll")
+                    .size_full()
+                    .overflow_y_scroll()
+                    .p(px(20.0))
+                    .child(
+                        div()
+                            .flex()
+                            .flex_col()
+                            .gap(px(18.0))
+                            .child(div().text_size(px(20.0)).child("Key Bindings"))
+                            .child(
+                                div()
+                                    .text_size(px(11.0))
+                                    .text_color(theme.text_muted)
+                                    .child(if cfg!(target_os = "macos") {
+                                        "Uses macOS keyboard shortcuts."
+                                    } else {
+                                        "Uses Windows/Linux keyboard shortcuts."
+                                    }),
+                            )
+                            .children(sections),
+                    ),
+            )
+    }
+}

--- a/crates/monocurl/src/main.rs
+++ b/crates/monocurl/src/main.rs
@@ -14,12 +14,14 @@ use std::{
 use crate::{
     actions::{
         CheckForUpdates, Copy, Cut, EpsilonBackward, EpsilonForward, ExportImage,
-        ExportSlidesAsVideos, ExportVideo, NextSlide, OpenSettings, Paste, PrevSlide, Quit, Redo,
-        SaveActiveDocument, SaveActiveDocumentCustomPath, SceneEnd, SceneStart, ToggleHeadlessMode,
-        TogglePlaying, TogglePresentationMode, ToggleSlideFold, Undo,
+        ExportSlidesAsVideos, ExportVideo, NextSlide, OpenKeyBindings, OpenSettings, Paste,
+        PrevSlide, Quit, Redo, SaveActiveDocument, SaveActiveDocumentCustomPath, SceneEnd,
+        SceneStart, ToggleHeadlessMode, TogglePlaying, TogglePresentationMode, ToggleSlideFold,
+        Undo,
     },
     auto_update::AutoUpdater,
     editor::text_editor,
+    keybindings_window::KeyBindingsWindow,
     settings_window::SettingsWindow,
     state::{user_settings::UserSettings, window_state::WindowState},
     theme::ThemeSettings,
@@ -36,6 +38,7 @@ mod components;
 mod document_view;
 mod editor;
 mod home_view;
+mod keybindings_window;
 mod navbar_view;
 mod services;
 mod settings_window;
@@ -129,6 +132,7 @@ impl MonocurlLauncher {
     fn setup_global_actions(cx: &mut App) {
         cx.on_action(|_: &Quit, cx| cx.quit());
         cx.on_action(|_: &OpenSettings, cx| SettingsWindow::open(cx));
+        cx.on_action(|_: &OpenKeyBindings, cx| KeyBindingsWindow::open(cx));
         cx.on_action(|_: &CheckForUpdates, cx| {
             AutoUpdater::check_for_updates(cx.active_window(), cx);
         });
@@ -188,12 +192,17 @@ impl MonocurlLauncher {
             },
             Menu {
                 name: "Help".into(),
-                items: vec![MenuItem::action("Check for Updates...", CheckForUpdates)],
+                items: vec![
+                    MenuItem::action("Key Bindings", OpenKeyBindings),
+                    MenuItem::separator(),
+                    MenuItem::action("Check for Updates...", CheckForUpdates),
+                ],
             },
         ]);
     }
 
     fn setup_modules(cx: &mut App) {
+        components::prompt::init(cx);
         document_view::init(cx);
         text_editor::init(cx);
     }

--- a/crates/monocurl/src/state/window_state.rs
+++ b/crates/monocurl/src/state/window_state.rs
@@ -41,6 +41,53 @@ pub enum ActiveScreen {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 struct OpenDocumentSerde {
     pub path: PathBuf,
+    #[serde(default)]
+    pub workspace: DocumentWorkspaceState,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct DocumentWorkspaceState {
+    #[serde(default)]
+    pub is_headless: bool,
+    #[serde(default = "default_console_visible")]
+    pub console_visible: bool,
+    #[serde(default = "default_split")]
+    pub main_split: f32,
+    #[serde(default = "default_split")]
+    pub viewport_timeline_split: f32,
+    #[serde(default = "default_console_split")]
+    pub console_split: f32,
+}
+
+const fn default_console_visible() -> bool {
+    false
+}
+const fn default_split() -> f32 {
+    0.5
+}
+const fn default_console_split() -> f32 {
+    0.68
+}
+
+impl Default for DocumentWorkspaceState {
+    fn default() -> Self {
+        Self {
+            is_headless: false,
+            console_visible: default_console_visible(),
+            main_split: default_split(),
+            viewport_timeline_split: default_split(),
+            console_split: default_console_split(),
+        }
+    }
+}
+
+impl DocumentWorkspaceState {
+    fn normalized(mut self) -> Self {
+        self.main_split = self.main_split.clamp(0.2, 0.8);
+        self.viewport_timeline_split = self.viewport_timeline_split.clamp(0.2, 0.8);
+        self.console_split = self.console_split.clamp(0.2, 0.8);
+        self
+    }
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -215,6 +262,7 @@ impl WindowState {
 
     fn make_open_document(
         path: PathBuf,
+        workspace: DocumentWorkspaceState,
         weak_state: WeakEntity<Self>,
         window: &mut Window,
         cx: &mut Context<Self>,
@@ -223,7 +271,17 @@ impl WindowState {
         let dirty = cx.new(|_cx| false);
         OpenDocument {
             path,
-            view: cx.new(|cx| DocumentView::new(view_path, weak_state, dirty.clone(), window, cx)),
+            view: cx.new(|cx| {
+                DocumentView::new(
+                    view_path,
+                    workspace.clone(),
+                    weak_state,
+                    dirty.clone(),
+                    window,
+                    cx,
+                )
+            }),
+            workspace,
         }
     }
 
@@ -277,6 +335,7 @@ impl WindowState {
                 if serde.path.exists() {
                     Some(Self::make_open_document(
                         serde.path,
+                        serde.workspace.normalized(),
                         weak_state.clone(),
                         window,
                         cx,
@@ -344,6 +403,7 @@ impl WindowState {
                 .iter()
                 .map(|doc| OpenDocumentSerde {
                     path: doc.path.clone(),
+                    workspace: doc.workspace.clone(),
                 })
                 .collect(),
             window_bounds: self.window_bounds,
@@ -516,12 +576,14 @@ impl WindowState {
                 view: cx.new(|cx| {
                     DocumentView::new(
                         path.clone(),
+                        DocumentWorkspaceState::default(),
                         window_state.downgrade(),
                         dirty.clone(),
                         window,
                         cx,
                     )
                 }),
+                workspace: DocumentWorkspaceState::default(),
             });
         }
 
@@ -534,6 +596,24 @@ impl WindowState {
         );
 
         self.focus_active_document(window, cx);
+        self.save();
+    }
+
+    pub fn update_document_workspace(
+        &mut self,
+        path: &Path,
+        update: impl FnOnce(&mut DocumentWorkspaceState),
+    ) {
+        let Some(document) = self
+            .open_documents
+            .iter_mut()
+            .find(|document| document.path == path)
+        else {
+            return;
+        };
+
+        update(&mut document.workspace);
+        document.workspace = document.workspace.clone().normalized();
         self.save();
     }
 }
@@ -570,5 +650,16 @@ mod tests {
         .unwrap();
 
         assert_eq!(restored, test_bounds(1020.0, 380.0, 900.0, 700.0));
+    }
+
+    #[test]
+    fn missing_workspace_state_uses_defaults() {
+        let saved: OpenDocumentSerde = serde_json::from_str(r#"{"path":"example.mcs"}"#).unwrap();
+
+        assert!(!saved.workspace.is_headless);
+        assert!(!saved.workspace.console_visible);
+        assert_eq!(saved.workspace.main_split, 0.5);
+        assert_eq!(saved.workspace.viewport_timeline_split, 0.5);
+        assert_eq!(saved.workspace.console_split, 0.68);
     }
 }

--- a/crates/monocurl/src/timeline/timeline_view.rs
+++ b/crates/monocurl/src/timeline/timeline_view.rs
@@ -1,8 +1,11 @@
+use std::{cell::Cell, rc::Rc};
+
 use executor::time::Timestamp;
 use gpui::*;
 
 use crate::{
     actions::{ZoomIn, ZoomOut},
+    components::split_pane::Split,
     editor::editor_view::Editor,
     services::ServiceManager,
     theme::ThemeSettings,
@@ -11,18 +14,12 @@ use crate::{
 use super::{
     console::render_console,
     metrics::{
-        DEFAULT_ZOOM_IDX, MIN_GAP, PX_PER_SEC, SLIDE_W, ZOOM_LEVELS, compute_gap_ws,
+        CONTENT_H, DEFAULT_ZOOM_IDX, MIN_GAP, PX_PER_SEC, SLIDE_W, ZOOM_LEVELS, compute_gap_ws,
         compute_playhead_x, compute_slide_xs, effective_durations,
     },
     toolbar::render_toolbar,
     track::render_track,
 };
-
-#[derive(Clone, Copy, PartialEq, Eq)]
-pub enum BottomPanelMode {
-    Timeline,
-    Console,
-}
 
 pub struct Timeline {
     pub(super) services: Entity<ServiceManager>,
@@ -30,7 +27,9 @@ pub struct Timeline {
     pub(super) scroll: ScrollHandle,
     pub(super) console_scroll: ScrollHandle,
     pub(super) zoom_idx: usize,
-    pub(super) panel_mode: BottomPanelMode,
+    pub(super) console_visible: bool,
+    console_split: Rc<Cell<f32>>,
+    on_console_change: Rc<dyn Fn(bool, f32, &mut App)>,
     is_scrubbing: bool,
 }
 
@@ -38,6 +37,9 @@ impl Timeline {
     pub fn new(
         services: Entity<ServiceManager>,
         editor: WeakEntity<Editor>,
+        console_visible: bool,
+        console_split: f32,
+        on_console_change: Rc<dyn Fn(bool, f32, &mut App)>,
         cx: &mut Context<Self>,
     ) -> Self {
         let execution_state = services.read(cx).execution_state().clone();
@@ -65,7 +67,9 @@ impl Timeline {
             scroll: ScrollHandle::new(),
             console_scroll: ScrollHandle::new(),
             zoom_idx: DEFAULT_ZOOM_IDX,
-            panel_mode: BottomPanelMode::Timeline,
+            console_visible,
+            console_split: Rc::new(Cell::new(console_split)),
+            on_console_change,
             is_scrubbing: false,
         }
     }
@@ -94,19 +98,9 @@ impl Timeline {
 
     pub fn toggle_panel_mode(&mut self, cx: &mut Context<Self>) {
         self.is_scrubbing = false;
-        self.panel_mode = match self.panel_mode {
-            BottomPanelMode::Timeline => BottomPanelMode::Console,
-            BottomPanelMode::Console => BottomPanelMode::Timeline,
-        };
+        self.console_visible = !self.console_visible;
+        (self.on_console_change)(self.console_visible, self.console_split.get(), cx);
         cx.notify();
-    }
-
-    pub fn set_panel_mode(&mut self, mode: BottomPanelMode, cx: &mut Context<Self>) {
-        if self.panel_mode != mode {
-            self.is_scrubbing = false;
-            self.panel_mode = mode;
-            cx.notify();
-        }
     }
 
     pub(super) fn zoom_factor(&self) -> f32 {
@@ -315,29 +309,23 @@ impl Render for Timeline {
             current_time,
         );
 
-        let (console_entries, runtime_errors): (Vec<_>, Vec<_>) =
-            if self.panel_mode == BottomPanelMode::Console {
-                let services = self.services.read(cx);
-                let console_entries = services
-                    .execution_state()
-                    .read(cx)
-                    .transcript
-                    .iter()
-                    .flat_map(|s| s.entries.iter().cloned())
-                    .collect();
-                let runtime_errors = services
-                    .textual_state()
-                    .read(cx)
-                    .diagnostics()
-                    .diagnostics_list()
-                    .iter()
-                    .filter(|diagnostic| diagnostic.is_runtime())
-                    .map(|diagnostic| diagnostic.message.clone())
-                    .collect();
-                (console_entries, runtime_errors)
-            } else {
-                (Vec::new(), Vec::new())
-            };
+        let services = self.services.read(cx);
+        let console_entries = services
+            .execution_state()
+            .read(cx)
+            .transcript
+            .iter()
+            .flat_map(|s| s.entries.iter().cloned())
+            .collect();
+        let runtime_errors = services
+            .textual_state()
+            .read(cx)
+            .diagnostics()
+            .diagnostics_list()
+            .iter()
+            .filter(|diagnostic| diagnostic.is_runtime())
+            .map(|diagnostic| diagnostic.message.clone())
+            .collect();
 
         let toolbar = render_toolbar(
             self,
@@ -418,53 +406,61 @@ impl Render for Timeline {
                 )
         };
 
-        let body: AnyElement = match self.panel_mode {
-            BottomPanelMode::Timeline => {
-                let track = render_track(
-                    cx.weak_entity(),
-                    current_timestamp,
-                    target_timestamp,
-                    slide_count,
-                    slide_names,
-                    durations,
-                    minimum_durations,
-                    zoom,
-                    theme,
-                );
+        let track = render_track(
+            cx.weak_entity(),
+            current_timestamp,
+            target_timestamp,
+            slide_count,
+            slide_names,
+            durations,
+            minimum_durations,
+            zoom,
+            theme,
+        );
+        let timeline_body = div()
+            .relative()
+            .size_full()
+            .child(
                 div()
-                    .relative()
+                    .id("tl-scroll")
                     .flex()
-                    .flex_1()
-                    .min_h_0()
-                    .child(
-                        div()
-                            .id("tl-scroll")
-                            .flex()
-                            .size_full()
-                            .overflow_x_scroll()
-                            .track_scroll(&self.scroll)
-                            .on_mouse_down(MouseButton::Left, {
-                                let timeline = cx.weak_entity();
-                                move |event, window, cx| {
-                                    window.prevent_default();
-                                    cx.stop_propagation();
-                                    timeline
-                                        .update(cx, |timeline, cx| {
-                                            timeline.begin_scrub(event.position, cx);
-                                        })
-                                        .ok();
-                                }
-                            })
-                            .child(track),
-                    )
-                    .child(render_scrub_tracker(cx.weak_entity()))
-                    .child(zoom_controls(cx.weak_entity(), ZOOM_LEVELS[self.zoom_idx]))
-                    .into_any_element()
-            }
-            BottomPanelMode::Console => {
+                    .size_full()
+                    .overflow_x_scroll()
+                    .track_scroll(&self.scroll)
+                    .on_mouse_down(MouseButton::Left, {
+                        let timeline = cx.weak_entity();
+                        move |event, window, cx| {
+                            window.prevent_default();
+                            cx.stop_propagation();
+                            timeline
+                                .update(cx, |timeline, cx| timeline.begin_scrub(event.position, cx))
+                                .ok();
+                        }
+                    })
+                    .child(track),
+            )
+            .child(render_scrub_tracker(cx.weak_entity()))
+            .child(zoom_controls(cx.weak_entity(), ZOOM_LEVELS[self.zoom_idx]));
+
+        let body = if self.console_visible {
+            Split::new(
+                Axis::Vertical,
+                timeline_body.into_any_element(),
                 render_console(console_entries, runtime_errors, &self.console_scroll, theme)
-                    .into_any_element()
-            }
+                    .into_any_element(),
+            )
+            .default_flex(0.68)
+            .min_sizes(px(CONTENT_H + 10.0), px(60.0))
+            .flex_state(self.console_split.clone())
+            .on_flex_change({
+                let on_console_change = self.on_console_change.clone();
+                let console_visible = self.console_visible;
+                move |split, cx| on_console_change(console_visible, split, cx)
+            })
+            .divider_color(theme.split_divider)
+            .into_any_element()
+        } else {
+            timeline_body.into_any_element()
         };
 
         div()

--- a/crates/monocurl/src/timeline/toolbar.rs
+++ b/crates/monocurl/src/timeline/toolbar.rs
@@ -5,7 +5,7 @@ use crate::theme::ThemeSettings;
 use super::{
     icons::{TRANSPORT_BTN_H, TRANSPORT_BTN_W, TransportIcon, transport_icon},
     metrics::{TOOLBAR_H, slide_label, slide_title_label, visual_slide_time},
-    timeline_view::{BottomPanelMode, Timeline},
+    timeline_view::Timeline,
 };
 
 pub(super) fn render_toolbar(
@@ -117,51 +117,33 @@ pub(super) fn render_toolbar(
                 .child(title)
         }));
 
-    let panel_mode = timeline.panel_mode;
-    let panel_tab = |id: &'static str, label: &'static str, mode: BottomPanelMode| {
-        let is_active = panel_mode == mode;
-        let this = cx.weak_entity();
-        div()
-            .id(id)
-            .flex()
-            .flex_none()
-            .items_center()
-            .justify_center()
-            .h_full()
-            .px(px(12.0))
-            .border_l(px(0.5))
-            .border_color(theme.navbar_border)
-            .bg(if is_active {
-                theme.tab_active_background
-            } else {
-                theme.tab_background
-            })
-            .text_color(theme.timeline_text)
-            .text_size(px(11.0))
-            .cursor_pointer()
-            .child(label)
-            .on_click(move |_, _, cx| {
-                this.update(cx, |tl, cx| tl.set_panel_mode(mode, cx)).ok();
-            })
-    };
-
-    let panel_tabs = div()
+    let console_visible = timeline.console_visible;
+    let timeline = cx.weak_entity();
+    let console_toggle = div()
+        .id("tl-console-toggle")
         .flex()
-        .flex_row()
+        .flex_none()
         .items_center()
+        .justify_center()
         .h_full()
-        .border_t(px(0.5))
+        .px(px(12.0))
+        .border_l(px(0.5))
         .border_color(theme.navbar_border)
-        .child(panel_tab(
-            "tl-tab-timeline",
-            "Timeline",
-            BottomPanelMode::Timeline,
-        ))
-        .child(panel_tab(
-            "tl-tab-console",
-            "Console",
-            BottomPanelMode::Console,
-        ));
+        .bg(if console_visible {
+            theme.tab_active_background
+        } else {
+            theme.tab_background
+        })
+        .text_color(theme.timeline_text)
+        .text_size(px(11.0))
+        .cursor_pointer()
+        .hover(|style| style.opacity(0.85))
+        .child("Console")
+        .on_click(move |_, _, cx| {
+            timeline
+                .update(cx, |timeline, cx| timeline.toggle_panel_mode(cx))
+                .ok();
+        });
 
     div()
         .flex()
@@ -176,5 +158,5 @@ pub(super) fn render_toolbar(
         .pl(px(24.0))
         .child(center_group)
         .child(div().flex_1())
-        .child(panel_tabs)
+        .child(console_toggle)
 }

--- a/crates/stdlib/src/color.rs
+++ b/crates/stdlib/src/color.rs
@@ -6,7 +6,42 @@ use executor::{
 };
 use stdlib_macros::stdlib_func;
 
-use crate::read_float;
+use crate::{STRING_COMPATIBLE_DESC, read_float, stringify_value};
+
+fn parse_hex_color(value: &str) -> Result<[f64; 4], String> {
+    let value = value.strip_prefix('#').unwrap_or(value);
+    if !matches!(value.len(), 6 | 8) || !value.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        return Err("expected a 6- or 8-digit hexadecimal color, such as #009ee0".into());
+    }
+
+    let channel = |start| u8::from_str_radix(&value[start..start + 2], 16).unwrap() as f64 / 255.0;
+    Ok([
+        channel(0),
+        channel(2),
+        channel(4),
+        if value.len() == 8 { channel(6) } else { 1.0 },
+    ])
+}
+
+#[stdlib_func]
+pub async fn hex(executor: &mut Executor, stack_idx: usize) -> Result<Value, ExecutorError> {
+    let value = executor.state.stack(stack_idx).read_at(-1).clone();
+    let value = stringify_value(executor, value)
+        .await
+        .map_err(|error| match error {
+            ExecutorError::TypeError { got, .. } => {
+                ExecutorError::type_error_for(STRING_COMPATIBLE_DESC, got, "value")
+            }
+            other => other,
+        })?;
+    let color = parse_hex_color(&value).map_err(ExecutorError::invalid_operation)?;
+
+    Ok(Value::List(List::new_with(
+        color
+            .into_iter()
+            .map(|channel| VRc::new(Value::Float(channel))),
+    )))
+}
 
 #[stdlib_func]
 pub async fn hsv(executor: &mut Executor, stack_idx: usize) -> Result<Value, ExecutorError> {
@@ -35,4 +70,31 @@ pub async fn hsv(executor: &mut Executor, stack_idx: usize) -> Result<Value, Exe
         VRc::new(Value::Float(b + m)),
         VRc::new(Value::Float(a)),
     ])))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_hex_color;
+
+    #[test]
+    fn parses_rgb_hex_with_opaque_alpha() {
+        assert_eq!(
+            parse_hex_color("#009ee0").unwrap(),
+            [0.0, 158.0 / 255.0, 224.0 / 255.0, 1.0]
+        );
+    }
+
+    #[test]
+    fn parses_rgba_hex() {
+        assert_eq!(
+            parse_hex_color("009ee080").unwrap(),
+            [0.0, 158.0 / 255.0, 224.0 / 255.0, 128.0 / 255.0]
+        );
+    }
+
+    #[test]
+    fn rejects_invalid_hex() {
+        assert!(parse_hex_color("#09e").is_err());
+        assert!(parse_hex_color("#009eez").is_err());
+    }
 }

--- a/crates/stdlib/src/mesh/constructors.rs
+++ b/crates/stdlib/src/mesh/constructors.rs
@@ -1358,16 +1358,22 @@ pub async fn mk_label(executor: &mut Executor, stack_idx: usize) -> Result<Value
 
 #[stdlib_func]
 pub async fn mk_number(executor: &mut Executor, stack_idx: usize) -> Result<Value, ExecutorError> {
-    let value = crate::read_float(executor, stack_idx, -3, "value")?;
-    let decimal_places = read_optional_decimal_places(executor, stack_idx, -2, "decimal_places")?;
-    let include_sign = read_flag(executor, stack_idx, -1, "include_sign")?;
-    let meshes = text::render_number_with_quality(
-        value,
-        decimal_places,
-        include_sign,
-        1.0,
-        text_render_quality(executor),
-    )
+    let value = crate::read_float(executor, stack_idx, -4, "value")?;
+    let decimal_places = read_optional_decimal_places(executor, stack_idx, -3, "decimal_places")?;
+    let include_sign = read_flag(executor, stack_idx, -2, "include_sign")?;
+    let font = read_optional_string(executor, stack_idx, -1, "font")?;
+    let quality = text_render_quality(executor);
+    let meshes = match font {
+        Some(font) => {
+            let font = font_source_string(executor, stack_idx, &font)?;
+            let number =
+                text::format_number(value, decimal_places, include_sign).map_err(|error| {
+                    ExecutorError::invalid_invocation(format!("number format failed: {error:#}"))
+                })?;
+            text::render_text_with_font_and_quality(&number, 1.0, &font, quality)
+        }
+        None => text::render_number_with_quality(value, decimal_places, include_sign, 1.0, quality),
+    }
     .map_err(|error| {
         ExecutorError::invalid_invocation(format!("number render failed: {error:#}"))
     })?;

--- a/crates/stdlib/src/mesh/constructors.rs
+++ b/crates/stdlib/src/mesh/constructors.rs
@@ -1366,11 +1366,14 @@ pub async fn mk_number(executor: &mut Executor, stack_idx: usize) -> Result<Valu
     let meshes = match font {
         Some(font) => {
             let font = font_source_string(executor, stack_idx, &font)?;
-            let number =
-                text::format_number(value, decimal_places, include_sign).map_err(|error| {
-                    ExecutorError::invalid_invocation(format!("number format failed: {error:#}"))
-                })?;
-            text::render_text_with_font_and_quality(&number, 1.0, &font, quality)
+            text::render_number_with_font_and_quality(
+                value,
+                decimal_places,
+                include_sign,
+                1.0,
+                &font,
+                quality,
+            )
         }
         None => text::render_number_with_quality(value, decimal_places, include_sign, 1.0, quality),
     }

--- a/crates/stdlib/src/util/convert.rs
+++ b/crates/stdlib/src/util/convert.rs
@@ -6,6 +6,8 @@ use executor::{
 };
 use stdlib_macros::stdlib_func;
 
+const MAX_DECIMAL_PLACES: usize = 64;
+
 fn format_text_tag(tag: &[isize], target: &str) -> String {
     let tag = tag
         .iter()
@@ -50,16 +52,70 @@ async fn read_text_tag_list(
     Ok(out)
 }
 
+fn read_decimal_places(
+    executor: &Executor,
+    stack_idx: usize,
+) -> Result<Option<usize>, ExecutorError> {
+    match executor
+        .state
+        .stack(stack_idx)
+        .read_at(-1)
+        .clone()
+        .elide_lvalue()
+    {
+        Value::Nil => Ok(None),
+        Value::Integer(value) if (0..=MAX_DECIMAL_PLACES as i64).contains(&value) => {
+            Ok(Some(value as usize))
+        }
+        Value::Float(value)
+            if value.is_finite()
+                && value.fract() == 0.0
+                && (0.0..=MAX_DECIMAL_PLACES as f64).contains(&value) =>
+        {
+            Ok(Some(value as usize))
+        }
+        Value::Integer(_) | Value::Float(_) => Err(ExecutorError::InvalidArgument {
+            arg: "decimal_places",
+            message: "must be nil or a non-negative integer at most 64",
+        }),
+        other => Err(ExecutorError::type_error_for(
+            "nil / non-negative int",
+            other.type_name(),
+            "decimal_places",
+        )),
+    }
+}
+
 #[stdlib_func]
 pub async fn to_string(executor: &mut Executor, stack_idx: usize) -> Result<Value, ExecutorError> {
-    let s = crate::stringify_value(executor, executor.state.stack(stack_idx).peek().clone())
-        .await
-        .map_err(|error| match error {
-            ExecutorError::TypeError { got, .. } => {
-                ExecutorError::type_error(crate::STRING_COMPATIBLE_DESC, got)
-            }
-            other => other,
-        })?;
+    let decimal_places = read_decimal_places(executor, stack_idx)?;
+    let value = executor.state.stack(stack_idx).read_at(-2).clone();
+    let resolved = value.clone().elide_wrappers_rec(executor).await?;
+    let s = match (resolved, decimal_places) {
+        (Value::Integer(value), decimal_places) => {
+            text::format_number(value as f64, decimal_places, false)
+                .map_err(|error| ExecutorError::invalid_invocation(error.to_string()))?
+        }
+        (Value::Float(value), decimal_places) => text::format_number(value, decimal_places, false)
+            .map_err(|error| ExecutorError::invalid_invocation(error.to_string()))?,
+        (other, Some(_)) => {
+            return Err(ExecutorError::type_error_for(
+                "number",
+                other.type_name(),
+                "x",
+            ));
+        }
+        (_, None) => {
+            crate::stringify_value(executor, value)
+                .await
+                .map_err(|error| match error {
+                    ExecutorError::TypeError { got, .. } => {
+                        ExecutorError::type_error(crate::STRING_COMPATIBLE_DESC, got)
+                    }
+                    other => other,
+                })?
+        }
+    };
     Ok(Value::String(s.into()))
 }
 

--- a/crates/stdlib/src/util/lists.rs
+++ b/crates/stdlib/src/util/lists.rs
@@ -22,6 +22,9 @@ pub async fn list_len(executor: &mut Executor, stack_idx: usize) -> Result<Value
         .elide_cached_wrappers_rec()
     {
         Value::List(list) => Ok(Value::Integer(list.len() as i64)),
+        Value::Map(_) => Err(ExecutorError::invalid_operation(
+            "cannot iterate over a map directly; use map_items(map) to iterate [key, value] pairs",
+        )),
         other => Err(ExecutorError::type_error("list", other.type_name())),
     }
 }

--- a/crates/text/src/lib.rs
+++ b/crates/text/src/lib.rs
@@ -17,7 +17,8 @@ pub use config::{
 };
 pub use document::SpanMarker;
 pub use number::{
-    format_number, render_number, render_number_string_with_quality, render_number_with_quality,
+    format_number, render_number, render_number_string_with_quality,
+    render_number_with_font_and_quality, render_number_with_quality,
 };
 pub use render::{
     render_latex, render_latex_with_preamble, render_latex_with_preamble_and_quality,

--- a/crates/text/src/number.rs
+++ b/crates/text/src/number.rs
@@ -6,7 +6,10 @@ use geo::{
     simd::Float3,
 };
 
-use crate::{RenderQuality, render::render_tex_with_quality, render::validate_scale};
+use crate::{
+    RenderQuality,
+    render::{render_tex_with_quality, render_text_with_font_and_quality, validate_scale},
+};
 
 const DEFAULT_NUMBER_SIGNIFICANT_DIGITS: usize = 6;
 const MAX_NUMBER_DECIMAL_PLACES: usize = 64;
@@ -74,12 +77,34 @@ pub fn render_number_string_with_quality(
     scale: f32,
     quality: RenderQuality,
 ) -> Result<Vec<Arc<Mesh>>> {
+    render_number_string_with_glyphs(text, scale, |ch| render_number_glyph(ch, scale, quality))
+}
+
+pub fn render_number_with_font_and_quality(
+    value: f64,
+    decimal_places: Option<usize>,
+    include_sign: bool,
+    scale: f32,
+    font: &str,
+    quality: RenderQuality,
+) -> Result<Vec<Arc<Mesh>>> {
+    let text = format_number(value, decimal_places, include_sign)?;
+    render_number_string_with_glyphs(&text, scale, |ch| {
+        render_text_with_font_and_quality(&ch.to_string(), scale, font, quality)
+    })
+}
+
+fn render_number_string_with_glyphs(
+    text: &str,
+    scale: f32,
+    mut render_glyph: impl FnMut(char) -> Result<Vec<Arc<Mesh>>>,
+) -> Result<Vec<Arc<Mesh>>> {
     validate_scale(scale)?;
     if text.is_empty() {
         return Ok(Vec::new());
     }
 
-    let digit_advance = number_digit_advance(scale, quality)?;
+    let digit_advance = number_digit_advance(scale, &mut render_glyph)?;
     let tracking = NUMBER_GLYPH_TRACKING_AT_SCALE_1 * scale;
     let mut cursor = 0.0f32;
     let mut out = Vec::new();
@@ -90,7 +115,7 @@ pub fn render_number_string_with_quality(
             continue;
         }
 
-        let mut glyph = render_number_glyph(ch, scale, quality)?;
+        let mut glyph = render_glyph(ch)?;
         let Some((min, max)) = mesh_collection_bounds(&glyph) else {
             cursor += digit_advance;
             continue;
@@ -167,8 +192,11 @@ fn render_number_glyph(ch: char, scale: f32, quality: RenderQuality) -> Result<V
     render_tex_with_quality(&source, scale, quality)
 }
 
-fn number_digit_advance(scale: f32, quality: RenderQuality) -> Result<f32> {
-    let meshes = render_number_glyph('0', scale, quality)?;
+fn number_digit_advance(
+    scale: f32,
+    render_glyph: &mut impl FnMut(char) -> Result<Vec<Arc<Mesh>>>,
+) -> Result<f32> {
+    let meshes = render_glyph('0')?;
     let Some((min, max)) = mesh_collection_bounds(&meshes) else {
         return Ok(scale * 0.5);
     };

--- a/packages/monocurl/package-lock.json
+++ b/packages/monocurl/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "monocurl",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "monocurl",
-      "version": "0.2.9",
+      "version": "0.2.10",
       "license": "MIT",
       "dependencies": {
         "mathjax-full": "^3.2.2"

--- a/packages/monocurl/package.json
+++ b/packages/monocurl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "monocurl",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "description": "Browser-side TypeScript controller for the Monocurl WebAssembly runtime.",
   "type": "module",
   "exports": {


### PR DESCRIPTION
Adds optional fixed-decimal formatting to `to_string` and optional direct-font rendering to `Number`.

Custom-font numbers are composed from independently cached character meshes.

Validated with `cargo test -p integration_tests test_number_constructor` and `cargo test -p integration_tests test_to_string`.