### PR TITLE
skip non-sandboxable test during nix build

### DIFF
--- a/bundling/linux/nix/package.nix
+++ b/bundling/linux/nix/package.nix
@@ -128,6 +128,7 @@ in
           "live_values::test_number_constructor_accepts_decimal_and_sign_options"
           "live_values::test_tex_and_latex_accept_list_string_inputs"
           "live_values::test_text_tag_operator_tags_text_backends"
+          "live_values::test_number_constructor_accepts_custom_font"
 
           "number::tests::number_renderer_lays_out_cached_glyphs"
           "number::tests::decimal_point_sits_on_the_baseline"

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "crane": {
       "locked": {
-        "lastModified": 1781825982,
-        "narHash": "sha256-SlXKwIRIhrOSAcTjCB3ftPLzJWZStQIPS7J1FlZPnKk=",
+        "lastModified": 1785782307,
+        "narHash": "sha256-MPaRdVkf6zZP5fCPxYCi8Dr4pZzgmXzg8T9nVEbp3Mw=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "469fd08d0bcf6926321fa973c6777fbc87785dd7",
+        "rev": "2c71e194474d13de031d729b729c968ddbe3507f",
         "type": "github"
       },
       "original": {
@@ -35,11 +35,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1782175435,
-        "narHash": "sha256-EMzXKmnOtBQ2MnvpiNOm7E+kOMvdPrIKaeg52Tip2Uk=",
+        "lastModified": 1785747939,
+        "narHash": "sha256-D740uKsMbgsfK2oaDenJLLPIZfq7W0/g4KN/Fls8eKs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "89570f24e97e614aa34aa9ab1c927b6578a43775",
+        "rev": "104240a772428cc2e20d8fd86c9ddbb886bbaff2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
also updated flake.lock to keep it up-to-date