### PR TITLE
app: move the language picker into Settings

### DIFF
--- a/crates/monocurl/src/navbar_view.rs
+++ b/crates/monocurl/src/navbar_view.rs
@@ -3,22 +3,16 @@ use gpui::*;
 use crate::{
     components::buttons::link_button,
     document_view::OpenDocument,
-    i18n::{Language, Localization},
-    state::{
-        user_settings::UserSettings,
-        window_state::{ActiveScreen, WindowState},
-    },
+    i18n::Localization,
+    state::window_state::{ActiveScreen, WindowState},
     theme::{ThemeMode, ThemeSettings},
 };
 
 const NAVBAR_HEIGHT: f32 = 30.0;
-const LANGUAGE_TRIGGER_WIDTH: f32 = 48.0;
-const LANGUAGE_MENU_WIDTH: f32 = 132.0;
 
 pub struct Navbar {
     window_state: WeakEntity<WindowState>,
     tab_scroll: ScrollHandle,
-    language_menu_open: bool,
 }
 
 impl Navbar {
@@ -41,144 +35,7 @@ impl Navbar {
         Self {
             window_state: state,
             tab_scroll: ScrollHandle::new(),
-            language_menu_open: false,
         }
-    }
-
-    fn render_language_picker(
-        &self,
-        weak_navbar: WeakEntity<Self>,
-        cx: &mut Context<Self>,
-    ) -> impl IntoElement + use<> {
-        let theme = ThemeSettings::theme(cx);
-        let current = Localization::language(cx);
-        let popup = self.language_menu_open.then(|| {
-            deferred(
-                div()
-                    .id("language-menu")
-                    .absolute()
-                    .top(px(NAVBAR_HEIGHT))
-                    .left(px(0.0))
-                    .w(px(LANGUAGE_MENU_WIDTH))
-                    .py_1()
-                    .border_1()
-                    .border_color(theme.navbar_border)
-                    .bg(theme.tab_background)
-                    .child(Self::render_outside_language_tracker(weak_navbar))
-                    .children(
-                        Language::ALL
-                            .into_iter()
-                            .filter(|language| Localization::is_available(*language))
-                            .map(|language| {
-                                let is_active = language == current;
-                                div()
-                                    .id((ElementId::from("language-option"), language.code()))
-                                    .w_full()
-                                    .px_3()
-                                    .py_1()
-                                    .flex()
-                                    .items_center()
-                                    .justify_between()
-                                    .text_size(px(12.0))
-                                    .text_color(if is_active {
-                                        theme.accent
-                                    } else {
-                                        theme.text_primary
-                                    })
-                                    .cursor_pointer()
-                                    .hover({
-                                        let hover = theme.row_hover_overlay;
-                                        move |style| style.bg(hover)
-                                    })
-                                    .child(language.native_name())
-                                    .children(is_active.then_some("✓"))
-                                    .on_click(cx.listener(move |this, _, window, cx| {
-                                        window.prevent_default();
-                                        cx.stop_propagation();
-                                        this.language_menu_open = false;
-                                        UserSettings::update(cx, |settings| {
-                                            settings.set_language(language);
-                                        });
-                                        cx.notify();
-                                    }))
-                            }),
-                    ),
-            )
-            .with_priority(1)
-        });
-
-        div()
-            .relative()
-            .h_full()
-            .flex_none()
-            .child(
-                div()
-                    .id("language-picker")
-                    .h_full()
-                    .w(px(LANGUAGE_TRIGGER_WIDTH))
-                    .px_3()
-                    .flex()
-                    .items_center()
-                    .justify_center()
-                    .gap_1()
-                    .border_r(px(0.5))
-                    .border_color(theme.navbar_border)
-                    .bg(if self.language_menu_open {
-                        theme.tab_active_background
-                    } else {
-                        theme.navbar_background
-                    })
-                    .text_size(px(11.0))
-                    .text_color(theme.link_text)
-                    .cursor_pointer()
-                    .hover({
-                        let hover = theme.tab_active_background;
-                        move |style| style.bg(hover)
-                    })
-                    .child(current.code().to_uppercase())
-                    .child(if self.language_menu_open {
-                        "▴"
-                    } else {
-                        "▾"
-                    })
-                    .on_click(cx.listener(|this, _, window, cx| {
-                        window.prevent_default();
-                        cx.stop_propagation();
-                        this.language_menu_open = !this.language_menu_open;
-                        cx.notify();
-                    })),
-            )
-            .children(popup)
-    }
-
-    fn render_outside_language_tracker(weak_navbar: WeakEntity<Self>) -> impl IntoElement {
-        canvas(
-            |bounds, _, _| bounds,
-            move |popup_bounds, _, window, _cx| {
-                let trigger_bounds = Bounds::new(
-                    point(px(0.0), popup_bounds.origin.y - px(NAVBAR_HEIGHT)),
-                    size(px(LANGUAGE_TRIGGER_WIDTH), px(NAVBAR_HEIGHT)),
-                );
-
-                window.on_mouse_event(move |event: &MouseDownEvent, phase, _window, cx| {
-                    if phase == DispatchPhase::Capture
-                        && !trigger_bounds.contains(&event.position)
-                        && !popup_bounds.contains(&event.position)
-                    {
-                        weak_navbar
-                            .update(cx, |this, cx| {
-                                this.language_menu_open = false;
-                                cx.notify();
-                            })
-                            .ok();
-                    }
-                });
-            },
-        )
-        .absolute()
-        .top(px(0.0))
-        .left(px(0.0))
-        .size_full()
     }
 
     fn render_tab(
@@ -336,7 +193,6 @@ impl Navbar {
 
 impl Render for Navbar {
     fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
-        let language_picker = self.render_language_picker(cx.weak_entity(), cx);
         let entity = self.window_state.upgrade().unwrap();
         let state = entity.read(cx);
         let theme = ThemeSettings::theme(cx);
@@ -401,7 +257,6 @@ impl Render for Navbar {
                     .h_full()
                     .flex_1()
                     .min_w_0()
-                    .child(language_picker)
                     .child(
                         div()
                             .bg(if is_home {

--- a/crates/monocurl/src/settings_window.rs
+++ b/crates/monocurl/src/settings_window.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 use gpui::*;
 
 use crate::{
-    i18n::Localization,
+    i18n::{Language, Localization},
     state::user_settings::{LatexBackendPreference, UserSettings},
     theme::{FontSet, ThemeSettings},
 };
@@ -36,7 +36,7 @@ pub struct SettingsWindow {
 
 impl SettingsWindow {
     pub fn open(cx: &mut App) {
-        let window_size = size(px(420.0), px(340.0));
+        let window_size = size(px(420.0), px(430.0));
         if !cx.has_global::<SettingsWindowHandle>() {
             cx.set_global(SettingsWindowHandle::default());
         }
@@ -87,6 +87,46 @@ impl SettingsWindow {
         Self {
             focus_handle: cx.focus_handle(),
         }
+    }
+
+    fn language_button(&self, language: Language, active: bool, cx: &mut Context<Self>) -> AnyElement {
+        let theme = ThemeSettings::theme(cx);
+        let bg = if active {
+            theme.accent
+        } else {
+            theme.tab_active_background
+        };
+        let text = if active {
+            theme.viewport_stage_background
+        } else {
+            theme.text_primary
+        };
+
+        div()
+            .id(ElementId::Name(format!("settings-language-{}", language.code()).into()))
+            .px(px(12.0))
+            .py(px(6.0))
+            .rounded(px(5.0))
+            .border_1()
+            .border_color(if active {
+                theme.accent
+            } else {
+                theme.navbar_border
+            })
+            .bg(bg)
+            .text_size(px(12.0))
+            .text_color(text)
+            .cursor_pointer()
+            .hover(|style| style.opacity(0.92))
+            .child(language.native_name())
+            .on_click(move |_, window, cx| {
+                window.prevent_default();
+                cx.stop_propagation();
+                UserSettings::update(cx, |settings| {
+                    settings.set_language(language);
+                });
+            })
+            .into_any_element()
     }
 
     fn backend_button(
@@ -388,6 +428,44 @@ impl Render for SettingsWindow {
                     .flex()
                     .flex_col()
                     .gap(px(14.0))
+                    .child(
+                        div()
+                            .flex()
+                            .flex_col()
+                            .gap(px(9.0))
+                            .child(
+                                div()
+                                    .text_size(px(12.0))
+                                    .font_weight(FontWeight::SEMIBOLD)
+                                    .child(Localization::text(cx, "settings.language")),
+                            )
+                            .child(
+                                div()
+                                    .text_size(px(10.0))
+                                    .text_color(theme.text_muted)
+                                    .child(Localization::text(cx, "settings.language.description")),
+                            )
+                            .child(
+                                div()
+                                    .flex()
+                                    .flex_row()
+                                    .flex_wrap()
+                                    .gap(px(8.0))
+                                    .pt(px(2.0))
+                                    .children(
+                                        Language::ALL
+                                            .into_iter()
+                                            .filter(|language| Localization::is_available(*language))
+                                            .map(|language| {
+                                                self.language_button(
+                                                    language,
+                                                    language == settings.language,
+                                                    cx,
+                                                )
+                                            }),
+                                    ),
+                            ),
+                    )
                     .child(
                         div()
                             .flex()


### PR DESCRIPTION
The `EN ▾` dropdown sat at the far-left of the navbar, ahead of the Home tab. Language is a set-once preference, so it moves to the Settings window alongside auto-update and the LaTeX backend.

- `navbar_view`: remove `render_language_picker` + outside-click tracker + `language_menu_open` state + `LANGUAGE_*` consts
- `settings_window`: new **Language** section — one button per available language (native names), reuses the `settings.language` / `settings.language.description` keys already present in every catalog; window grows 340→430px

🤖 Generated with [Claude Code](https://claude.com/claude-code)